### PR TITLE
add other ip/fqdn to cert

### DIFF
--- a/inventory/sample/group_vars/rke2_servers.yml
+++ b/inventory/sample/group_vars/rke2_servers.yml
@@ -13,6 +13,11 @@ rke2_config:
 # etcd-snapshot-retention
 # etcd_snapshot_retention: 56
 
+# tls-san
+# tls_san:
+#  - "k8s.mydomain.intra"
+#  - "172.17.9.10"
+
 # node-label
 rke2_node_labels:
   - "ansible-provisioned-server=true"

--- a/roles/rke2_common/tasks/config.yml
+++ b/roles/rke2_common/tasks/config.yml
@@ -69,3 +69,24 @@
     path: /etc/rancher/rke2/config.yaml
     line: 'etcd-snapshot-retention: {{ etcd_snapshot_retention }}'
   when: etcd_snapshot_retention is defined
+
+- name: Add node-ip
+  lineinfile:
+    dest: /etc/rancher/rke2/config.yaml
+    line: "node-ip: {{ hostvars[inventory_hostname].node_ip }}"
+  when: hostvars[inventory_hostname].node_ip is not undefined
+
+- name: Add tls-san line
+  lineinfile:
+    path: /etc/rancher/rke2/config.yaml
+    line: 'tls-san:'
+  when: tls_san is defined
+
+- name: Add tls-san lines
+  lineinfile:
+    path: /etc/rancher/rke2/config.yaml
+    insertafter: 'tls-san:'
+    line: "  - {{ item }}"
+  with_items:
+    - "{{ tls_san }}"
+  when: tls_san is defined


### PR DESCRIPTION
### Proposed changes
Add ability to add multiple ips or fqdns to the cluster cert.

This fixes #43 